### PR TITLE
Use ardupilot's fork of IDL parser instead

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "thirdparty/IDL-Parser"]
-	path = thirdparty/IDL-Parser
-    url = https://github.com/eProsima/IDL-Parser.git
+    path = thirdparty/IDL-Parser
+    url = https://github.com/ardupilot/OMG-IDL-Parser.git


### PR DESCRIPTION
Prefer the internal mirror when cloning. This requires keeping both forks up to date. 