### PR TITLE
Support namespaced constexpr constants in C++ and macros in C

### DIFF
--- a/src/main/java/com/eprosima/microxrcedds/idl/grammar/Context.java
+++ b/src/main/java/com/eprosima/microxrcedds/idl/grammar/Context.java
@@ -48,6 +48,13 @@ public class Context extends com.eprosima.idl.context.Context implements com.epr
         return m_typelimitation;
     }
 
+    public String getCScope()
+    {
+        String[] scopeTemp = getScope().split("::");
+        String scope = String.join("_", scopeTemp).replace("_Constants", "");
+        return scope;
+    }
+
     @Override
     public StructTypeCode createStructTypeCode(String name)
     {

--- a/src/main/java/com/eprosima/microxrcedds/idl/templates/TypesHeader.stg
+++ b/src/main/java/com/eprosima/microxrcedds/idl/templates/TypesHeader.stg
@@ -51,7 +51,7 @@ $definitions; separator="\n"$
 
 annotation(ctx, annotation) ::= <<>>
 const_decl(ctx, parent, const, const_type) ::= <<
-#define $const.name$ $const.value$
+static const $const.typeCode.cppTypename$ $ctx.cScope$_$const.name$ = $const.value$;
 >>
 
 typedef_decl(ctx, parent, typedefs, typedefs_type, declarator_type) ::= <<


### PR DESCRIPTION
This addition will allow AP_DDS to access global constants as namespace variables solving this issue https://github.com/eProsima/Micro-XRCE-DDS-Gen/issues/81