### PR TITLE
Fix typo: jave_exec -> java_exec in microvcodedsgen

### DIFF
--- a/scripts/microxrceddsgen
+++ b/scripts/microxrceddsgen
@@ -4,7 +4,7 @@ dir="`dirname \"$0\"`"
 
 java_exec=java
 
-if ! hash ${jave_exec}; then
+if ! hash ${java_exec}; then
     [ -z "$JAVA_HOME" ] && { echo "Java binary cannot be found. Please, make sure its location is in the PATH environment variable or set JAVA_HOME environment variable."; exit 1; }
     java_exec="${JAVA_HOME}/bin/java"
 fi

--- a/scripts/microxrceddsgen.in
+++ b/scripts/microxrceddsgen.in
@@ -4,7 +4,7 @@ dir="`dirname \"$0\"`"
 
 java_exec=java
 
-if ! hash ${jave_exec}; then
+if ! hash ${java_exec}; then
     [ -z "$JAVA_HOME" ] && { echo "Java binary cannot be found. Please, make sure its location is in the PATH environment variable or set JAVA_HOME environment variable."; exit 1; }
     java_exec="${JAVA_HOME}/bin/java"
 fi


### PR DESCRIPTION
Fixed a typo where the variable was defined as `jave_exec` but referenced as `java_exec`, causing the script to check an undefined variable.

This corrects the variable name to `java_exec` throughout both files Microxrceddsgen and Microxrceddsgen.in